### PR TITLE
Render font for score

### DIFF
--- a/src/project.v
+++ b/src/project.v
@@ -8,9 +8,9 @@
 module tt_um_uwasic_dinogame (
     input  wire [7:0] ui_in,    // Dedicated inputs
     output wire [7:0] uo_out,   // Dedicated outputs
-    input  wire [7:0] uio_in,   // IOs: Input path
-    output wire [7:0] uio_out,  // IOs: Output path
-    output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+    input  wire [7:8] uio_in,   // IOs: Input path
+    output wire [7:8] uio_out,  // IOs: Output path
+    output wire [7:8] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
     input  wire       ena,      // always 1 when the design is powered, so you can ignore it
     input  wire       clk,      // clock
     input  wire       rst_n     // reset_n - low to reset
@@ -103,9 +103,12 @@ module tt_um_uwasic_dinogame (
     wire score_color;
     wire [5:0] dino_rom_counter;
     wire [2:0] obs_rom_counter;
+    wire [3:0] score_rom_address;
+    wire [9:0] score_rom_output;
  
     dino_rom dino_rom_inst (.clk(clk), .rst(~rst_n), .i_rom_counter(dino_rom_counter), .o_sprite_color(dino_color));
     obs_rom obs_rom_inst (.clk(clk), .rst(~rst_n), .i_rom_counter(obs_rom_counter), .o_sprite_color(obs_color));
+    score_rom score_rom_inst (.clk(clk), .rst(~rst_n), .address(score_rom_address), .data(score_rom_output));
   
     score_render #(.CONV(CONV)) score_inst (.clk(clk), .rst(~rst_n), .num(), .i_hpos(hpos), .i_vpos(vpos), .o_score_color(score_color));
     dino_render #(.CONV(CONV)) dino_inst  (.clk(clk), .rst(~rst_n), .i_hpos(hpos), .i_vpos(vpos), .o_color_dino(color_dino), .o_rom_counter(dino_rom_counter), .i_sprite_color(dino_color));

--- a/src/score_render.v
+++ b/src/score_render.v
@@ -12,28 +12,37 @@ module score_render #(parameter CONV = 0) (
 reg [9:CONV] y_offset;
 reg [9:CONV] x_offset;
 reg in_sprite;
-reg [7:0] segment;
+reg [9:0] rom_data;
+wire [9:0] rom_output;
+reg [3:0] rom_address;
+reg [3:0] digit_select;
 
 always @(*) begin
   y_offset = i_vpos - 1;
   x_offset = i_hpos - 28;
   in_sprite = (x_offset < 4) && (y_offset < 7);
   
-  segment[0] = y_offset == 0 && (num == 0 || num == 2 || num == 3 || num == 5 || num == 6 || num == 7 || num == 8 || num == 9);
-  segment[1] = y_offset < 3 && x_offset == 0 && (num == 0 || num == 4 || num == 5 || num == 6 || num == 8 || num == 9);
-  segment[2] = y_offset < 3 && x_offset == 3 && (num == 0 || num == 1 || num == 2 || num == 3 || num == 4 || num == 7|| num == 8 || num == 9);
-  segment[3] = y_offset == 3 && (num == 2 || num == 3 || num == 4 || num == 5 || num == 6 || num == 8 || num == 9);
-  segment[4] = y_offset > 3  && x_offset == 0 && (num == 0 || num == 2 || num == 6 || num == 8);
-  segment[5] = y_offset > 3 && x_offset == 3 && (num == 0 || num == 1 || num == 3 || num == 4 || num == 5 || num == 6 || num == 7 || num == 8 || num == 9);
-  segment[6] = y_offset == 6 && (num == 0 || num == 2 || num == 3 || num == 5|| num == 6 || num == 8);
+  rom_address = y_offset * 4 + x_offset;
+  digit_select = num;
 end 
 
-always @(*) begin
-  o_score_color = |segment && in_sprite;
-  //o_score_color = 1;
+always @(posedge clk or posedge rst) begin
+  if (rst) begin
+    rom_data <= 10'b0;
+  end else begin
+    rom_data <= rom_output;
+  end
 end
 
+always @(*) begin
+  o_score_color = rom_data[digit_select] && in_sprite;
+end
+
+score_rom score_rom_inst (
+  .clk(clk),
+  .rst(rst),
+  .address(rom_address),
+  .data(rom_output)
+);
+
 endmodule
-
-
-

--- a/src/score_rom.v
+++ b/src/score_rom.v
@@ -1,0 +1,47 @@
+`default_nettype none
+
+module score_rom (
+  input  wire       clk,      // clock
+  input  wire       rst, 
+  input  wire [3:0] address,
+  output reg [9:0] data
+);
+
+reg [9:0] rom [0:27];
+
+always @(posedge clk or posedge rst) begin
+  if (rst) begin
+    rom[0]  <= 10'b1111111110; // 0
+    rom[1]  <= 10'b0110000110; // 1
+    rom[2]  <= 10'b1101101101; // 2
+    rom[3]  <= 10'b1111001111; // 3
+    rom[4]  <= 10'b0110011111; // 4
+    rom[5]  <= 10'b1011011111; // 5
+    rom[6]  <= 10'b1011111111; // 6
+    rom[7]  <= 10'b1110000110; // 7
+    rom[8]  <= 10'b1111111111; // 8
+    rom[9]  <= 10'b1111011111; // 9
+    rom[10] <= 10'b0000000000; // blank
+    rom[11] <= 10'b0000000000; // blank
+    rom[12] <= 10'b0000000000; // blank
+    rom[13] <= 10'b0000000000; // blank
+    rom[14] <= 10'b0000000000; // blank
+    rom[15] <= 10'b0000000000; // blank
+    rom[16] <= 10'b0000000000; // blank
+    rom[17] <= 10'b0000000000; // blank
+    rom[18] <= 10'b0000000000; // blank
+    rom[19] <= 10'b0000000000; // blank
+    rom[20] <= 10'b0000000000; // blank
+    rom[21] <= 10'b0000000000; // blank
+    rom[22] <= 10'b0000000000; // blank
+    rom[23] <= 10'b0000000000; // blank
+    rom[24] <= 10'b0000000000; // blank
+    rom[25] <= 10'b0000000000; // blank
+    rom[26] <= 10'b0000000000; // blank
+    rom[27] <= 10'b0000000000; // blank
+  end else begin
+    data <= rom[address];
+  end
+end
+
+endmodule


### PR DESCRIPTION
Add logic to use a single ROM with a 10-bit wide data bus for rendering digits in the `score_render` module.